### PR TITLE
#167061943 - Admin can get all orders. 

### DIFF
--- a/app/menu.py
+++ b/app/menu.py
@@ -31,13 +31,13 @@ def return_menu():
     menu_items = Menu.query.all()
     entire_menu = []
     for menu_item in menu_items:
-        obj = {
+        menu_dict = {
             'id': menu_item.id,
             'name': menu_item.name,
             'price': menu_item.price,
             'description': menu_item.description
         }
-        entire_menu.append(obj)
+        entire_menu.append(menu_dict)
     return jsonify(menu_items=entire_menu), 200
 
 
@@ -46,10 +46,10 @@ def return_menu():
 def return_menu_item(menu_id):
     """Return single menu item of specified id"""
     menu_item = Menu.find(int(menu_id))
-    menu_obj = {
+    menu_dict = {
         'id': menu_item.id,
         'name': menu_item.name,
         'price': menu_item.price,
         'description': menu_item.description
     }
-    return jsonify(menu_item=menu_obj), 200
+    return jsonify(menu_item=menu_dict), 200

--- a/app/order.py
+++ b/app/order.py
@@ -34,3 +34,22 @@ def create_order():
         return jsonify(
             error=f"Menu item {input_data['menu_id']} not found"), 404
     return jsonify(message=f"Order posted"), 201
+
+
+@bp.route('/', methods=['GET'])
+@jwt_required
+@admin_required
+def get_all_orders():
+    """Method to return all orders for the admin"""
+    order_items = Order.query.all()
+    order_list = []
+    for order_item in order_items:
+        order_dict = {
+            'id': order_item.id,
+            'menu_id': order_item.menu_id,
+            'quantity': order_item.quantity,
+            'status': order_item.status,
+            'date_created': order_item.date_created
+        }
+        order_list.append(order_dict)
+    return jsonify(order_list=order_list), 200

--- a/run
+++ b/run
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#rebuild web to include new changes
+docker-compose build web
+
+#run containers
+docker-compose up -d
+
+#run tests
+docker exec -it fastfood-flask_web_1 pytest

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -38,4 +38,4 @@ class MenuTestCase(BaseTest):
         res = self.client().get(
             '/menu/', headers={'Authorization': 'Bearer ' + self.token})
         self.assertEqual(res.status_code, 200)
-        self.assertIn(b'pilau_12', res.data)
+        self.assertIn(b'menu_items', res.data)

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -28,11 +28,33 @@ class OrderTestCase(BaseTest):
         self.assertIn(b'not found', res.data)
 
     def test_string_input(self):
+        """Test api does not allow string input for order"""
         res = post_json_header(
             self.client, '/orders/', order_strings, self.token)
         self.assertEqual(res.status_code, 400)
 
     def test_incomplete_order(self):
+        """Test orders input handles incomplete orders"""
         res = post_json_header(
             self.client, '/orders/', incomplete_order, self.token)
         self.assertEqual(res.status_code, 400)
+
+    def test_return_orders(self):
+        """Test orders endpoint returns orders when accessed by admin"""
+        res = post_json_header(
+            self.client, '/orders/', create_order(
+                self.create_menu()), self.token)
+        res = self.client().get(
+            '/orders/', headers={
+                'Authorization': 'Bearer ' + self.admin_token})
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(b'order_list', res.data)
+
+    def test_unauthorized_access_orders(self):
+        """Ensures /orders endpoint not accessable by users"""
+        res = post_json_header(
+            self.client, '/orders/', create_order(
+                self.create_menu()), self.token)
+        res = self.client().get(
+            '/orders/', headers={'Authorization': 'Bearer ' + self.token})
+        self.assertEqual(res.status_code, 401)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,5 @@ skipsdist=True
 deps =
     -rrequirements.txt
 commands =
-    pytest -v
     coverage run -m pytest
     coverage report


### PR DESCRIPTION
#### What does this PR do? 
- Add ability for admin to view all orders. 

#### Description of tasks completed. 
- Add /orders endpoint. 
- Secure endpoint so that only admin can use it. 
- Write tests for functionality. 

#### How to test this. 
- Checkout the branch ft-get-orders-167061943
- Login as an admin and send a get request to the endpoint `/orders/`

#### Relevant user stories. 
[#167061943](https://www.pivotaltracker.com/story/show/167061943)